### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/Semaphore/keywords.txt
+++ b/Semaphore/keywords.txt
@@ -1,8 +1,8 @@
-Semaphore   KEYWORD1
-red         KEYWORD2
-yellow      KEYWORD2
-green       KEYWORD2
-red_yellow  KEYWORD2
-off         KEYWORD2
+Semaphore	KEYWORD1
+red	KEYWORD2
+yellow	KEYWORD2
+green	KEYWORD2
+red_yellow	KEYWORD2
+off	KEYWORD2
 
-DISABLE     LITERAL1
+DISABLE	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords